### PR TITLE
Use ManualReset event instead of thread context switching.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,8 @@ _TeamCity*
 _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
+*.ncrunchproject
+*.ncrunchsolution
 
 # MightyMoose
 *.mm.*

--- a/src/Cake.Scripting/Extensions/TypeDefinitionExtensions.cs
+++ b/src/Cake.Scripting/Extensions/TypeDefinitionExtensions.cs
@@ -14,10 +14,17 @@ namespace Cake.Scripting
         {
             if (!type.IsDefinition && !type.IsGenericParameter)
             {
-                var resolved = type.Resolve();
-                if (resolved != null)
+                try
                 {
-                    return resolved;
+                    var resolved = type.Resolve();
+                    if (resolved != null)
+                    {
+                        return resolved;
+                    }
+                }
+                catch (Exception e)
+                {
+                    return null;
                 }
             }
             return null;

--- a/tests/integration/Cake.Bakery.IntegrationTests/IntegrationTests.cs
+++ b/tests/integration/Cake.Bakery.IntegrationTests/IntegrationTests.cs
@@ -18,6 +18,7 @@ namespace Cake.Bakery.IntegrationTests
         }
 
         [Fact]
+        [Trait("Category", "Integration")]
         public void ShouldGenerateFromFile()
         {
             // Given
@@ -36,6 +37,7 @@ namespace Cake.Bakery.IntegrationTests
         }
 
         [Fact]
+        [Trait("Category", "Integration")]
         public void ShouldGenerateFromBuffer()
         {
             // Given
@@ -68,6 +70,7 @@ RunTarget(target);";
         }
 
         [Fact]
+        [Trait("Category", "Integration")]
         public void ShouldGenerateWitLineChanges()
         {
             // Given


### PR DESCRIPTION
Also took the liberty of adding category trait attributes for integration tests to be able to filter them out when running tests from within Visual Studio (NCrunch fails when running them).

Also added some missing NCrunch file types to `.gitignore`.