### PR TITLE
GH49: Search for Cake.exe instead of Cake.Core.dll

### DIFF
--- a/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
@@ -214,7 +214,7 @@ namespace Cake.Scripting.CodeGen
 
         private DirectoryPath GetCakePath(DirectoryPath toolPath)
         {
-            var pattern = string.Concat(toolPath.FullPath, "/**/Cake.Core.dll");
+            var pattern = string.Concat(toolPath.FullPath, "/**/Cake.exe");
             var cakeCorePath = _globber.GetFiles(pattern).FirstOrDefault();
 
             return cakeCorePath?.GetDirectory().MakeAbsolute(_environment) ?? toolPath.Combine("Cake").Collapse();


### PR DESCRIPTION
- Fixes #49 