### PR TITLE
GH62: Add project metadata used for AssemblyInfo and NuGet packages.

### DIFF
--- a/nuspec/Cake.Bakery.nuspec
+++ b/nuspec/Cake.Bakery.nuspec
@@ -6,8 +6,8 @@
     <authors>Patrik Svensson, Mattias Karlsson, Gary Ewan Park, Alistair Chapman, Martin Björkström and contributors</authors>
     <description>The Cake script analyzer and code generator.</description>
     <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
-    <licenseUrl>https://github.com/cake-build/cake/blob/develop/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/cake-build/cake</projectUrl>
+    <licenseUrl>https://github.com/cake-build/bakery/blob/develop/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/cake-build/bakery</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>

--- a/src/Cake.Bakery.Tests/Cake.Bakery.Tests.csproj
+++ b/src/Cake.Bakery.Tests/Cake.Bakery.Tests.csproj
@@ -4,6 +4,12 @@
     <TargetFrameworks>net46</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>The Cake script analyzer and code generator.</Description>
+  </PropertyGroup>
+
+  <Import Project="..\Shared.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/src/Cake.Bakery/Cake.Bakery.csproj
+++ b/src/Cake.Bakery/Cake.Bakery.csproj
@@ -8,6 +8,12 @@
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>The Cake script analyzer and code generator.</Description>
+  </PropertyGroup>
+
+  <Import Project="..\Shared.props" />
+
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.23.0-alpha0059" />
     <PackageReference Include="Cake.NuGet" Version="0.23.0-alpha0059" />

--- a/src/Cake.Scripting.Abstractions/Cake.Scripting.Abstractions.csproj
+++ b/src/Cake.Scripting.Abstractions/Cake.Scripting.Abstractions.csproj
@@ -6,4 +6,10 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>The Cake script analyzer and code generator.</Description>
+  </PropertyGroup>
+
+  <Import Project="..\Shared.props" />
+
 </Project>

--- a/src/Cake.Scripting.Tests/Cake.Scripting.Tests.csproj
+++ b/src/Cake.Scripting.Tests/Cake.Scripting.Tests.csproj
@@ -4,6 +4,12 @@
     <TargetFrameworks>net46</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>The Cake script analyzer and code generator.</Description>
+  </PropertyGroup>
+
+  <Import Project="..\Shared.props" />
+
   <ItemGroup>
     <None Remove="Data\Expected\Methods\Generic_ExtensionMethod" />
     <None Remove="Data\Expected\Methods\Generic_ExtensionMethodWithGenericOutParameter" />

--- a/src/Cake.Scripting.Transport.Tests/Cake.Scripting.Transport.Tests.csproj
+++ b/src/Cake.Scripting.Transport.Tests/Cake.Scripting.Transport.Tests.csproj
@@ -4,6 +4,12 @@
     <TargetFrameworks>net46</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>The Cake script analyzer and code generator.</Description>
+  </PropertyGroup>
+
+  <Import Project="..\Shared.props" />
+
   <ItemGroup>
     <None Remove="Data\UTF-8-demo.txt" />
     <None Remove="Data\UTF-8-test.txt" />

--- a/src/Cake.Scripting.Transport/Cake.Scripting.Transport.csproj
+++ b/src/Cake.Scripting.Transport/Cake.Scripting.Transport.csproj
@@ -6,6 +6,12 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>The Cake script analyzer and code generator.</Description>
+  </PropertyGroup>
+
+  <Import Project="..\Shared.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.0" />
   </ItemGroup>

--- a/src/Cake.Scripting/Cake.Scripting.csproj
+++ b/src/Cake.Scripting/Cake.Scripting.csproj
@@ -6,6 +6,12 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>The Cake script analyzer and code generator.</Description>
+  </PropertyGroup>
+
+  <Import Project="..\Shared.props" />
+
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.23.0-alpha0059" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta5" />

--- a/src/Shared.props
+++ b/src/Shared.props
@@ -1,0 +1,21 @@
+<Project>
+
+   <!-- General package metadata -->
+  <PropertyGroup>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Copyright>Copyright (c) .NET Foundation and contributors</Copyright>
+    <Authors>Patrik Svensson, Mattias Karlsson, Gary Ewan Park, Alistair Chapman, Martin Björkström and contributors</Authors>
+    <Company>Patrik Svensson, Mattias Karlsson, Gary Ewan Park, Alistair Chapman, Martin Björkström and contributors</Company>
+    <PackageLicenseUrl>https://github.com/cake-build/bakery/blob/develop/LICENSE</PackageLicenseUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/cake-build/bakery</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>Cake;Script;Build</PackageTags>
+  </PropertyGroup>
+
+  <!-- Warnings as errors -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>  


### PR DESCRIPTION
- Fixes #62 