### PR TITLE
GH73: Add possibility to use logging.

### DIFF
--- a/src/Cake.Bakery/Constants.cs
+++ b/src/Cake.Bakery/Constants.cs
@@ -14,6 +14,7 @@ namespace Cake.Bakery
         {
             public static readonly string Port = "port";
             public static readonly string Debug = "debug";
+            public static readonly string Verbose = "verbose";
         }
     }
 }

--- a/src/Cake.Bakery/Diagnostics/Logger.cs
+++ b/src/Cake.Bakery/Diagnostics/Logger.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace Cake.Bakery.Diagnostics
+{
+    public class Logger : ILogger
+    {
+        private readonly TextWriter _stdErr;
+        private readonly TextWriter _stdOut;
+
+        public Logger()
+        {
+            _stdErr = Console.Error;
+            _stdOut = Console.Out;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var message = formatter(state, exception);
+
+            if (logLevel > LogLevel.Warning)
+            {
+                _stdErr.WriteLine(message);
+            }
+            else
+            {
+                _stdOut.WriteLine(message);
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return new DisposableScope();
+        }
+
+        private class DisposableScope : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Cake.Bakery/Diagnostics/LoggerProvider.cs
+++ b/src/Cake.Bakery/Diagnostics/LoggerProvider.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Cake.Bakery.Diagnostics
+{
+    public class LoggerProvider : ILoggerProvider
+    {
+        private readonly ILogger _logger;
+
+        public LoggerProvider()
+        {
+            _logger = new Logger();
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _logger;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Cake.Bakery/Program.cs
+++ b/src/Cake.Bakery/Program.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using Cake.Bakery.Arguments;
 using Cake.Bakery.Composition;
+using Cake.Bakery.Diagnostics;
 using Cake.Bakery.Polyfill;
 using Cake.Core;
 using Cake.Core.Configuration;
@@ -53,6 +54,10 @@ namespace Cake.Bakery
             }
 
             var loggerFactory = new LoggerFactory();
+            if (args.ContainsKey(Constants.CommandLine.Verbose))
+            {
+                loggerFactory.AddProvider(new LoggerProvider());
+            }
 
             var registrar = new ContainerRegistrar();
             registrar.RegisterModule(new CoreModule());

--- a/src/Cake.Scripting.Transport/Tcp/Client/ScriptGenerationProcess.cs
+++ b/src/Cake.Scripting.Transport/Tcp/Client/ScriptGenerationProcess.cs
@@ -28,10 +28,16 @@ namespace Cake.Scripting.Transport.Tcp.Client
 
         public void Start(int port, string workingDirectory)
         {
+            var arguments = $"--port={port}";
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                arguments += " --verbose";
+            }
+
             var startInfo = new ProcessStartInfo
             {
                 FileName = ServerExecutablePath,
-                Arguments = $"--port={port}",
+                Arguments = arguments,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -44,7 +50,7 @@ namespace Cake.Scripting.Transport.Tcp.Client
             {
                 if (e.Data != null)
                 {
-                    _logger.LogDebug(e.Data);
+                    _logger.LogError(e.Data);
                 }
             };
             _process.BeginErrorReadLine();

--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -56,7 +56,7 @@ const string CakeAddinDirectiveFile = "addin.cake";
 // Setup
 Setup((context) => {
     var loggerFactory = new LoggerFactory()
-        .AddConsole(Microsoft.Extensions.Logging.LogLevel.Information);
+        .AddConsole(Microsoft.Extensions.Logging.LogLevel.Debug);
 
     service = new ScriptGenerationClient(
         MakeAbsolute(context.Tools.Resolve("Cake.Bakery.exe")).FullPath,


### PR DESCRIPTION
Adds simple logging if `--verbose` is given as cmdline arg (this will automatically happen if LogLevel.Debug is enabled). This will log everything from Cake. Error and Critical goes to STDERR and will be logged as Error on client side while rest is logged to STDOUT and will be logged as Debug on client side.