### PR TITLE
GH76: Look for LF instead of CRLF

### DIFF
--- a/src/Cake.Scripting/CodeGen/Generators/CakeAliasGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/Generators/CakeAliasGenerator.cs
@@ -19,7 +19,7 @@ namespace Cake.Scripting.CodeGen.Generators
                 var builder = new StringBuilder();
                 foreach (var xmlDoc in element.Elements())
                 {
-                    builder.AppendLine($"/// {xmlDoc.ToString().Replace("\r\n", "\r\n///")}");
+                    builder.AppendLine($"/// {xmlDoc.ToString().Replace("\n", "\n///")}");
                 }
                 writer.Write(builder.ToString());
             }


### PR DESCRIPTION
- Fixes #76

Problem was with generated documentation for aliases.

Example before on Linux:
```
/// <summary>
            Determines whether or not the specified argument exist.
            </summary>
/// <param name="context">The context.</param>
/// <param name="name">The argument name.</param>
/// <returns>Whether or not the specified argument exist.</returns>
/// <example>
            This sample shows how to call the <see cref="M:Cake.Common.ArgumentAliases.HasArgument(Cake.Core.ICakeContext,System.String)" /> method.
            <code>
            var argumentName = "myArgument";
            //Cake.exe .\hasargument.cake -myArgument="is specified"
            if (HasArgument(argumentName))
            {
                Information("{0} is specified", argumentName);
            }
            //Cake.exe .\hasargument.cake
            else
            {
                Warning("{0} not specified", argumentName);
            }
            </code>
            </example>
public System.Boolean HasArgument(System.String name)
{
    return Cake.Common.ArgumentAliases.HasArgument(Context, name);
}
```
vs fix...
```
/// <summary>
///            Determines whether or not the specified argument exist.
///            </summary>
/// <param name="context">The context.</param>
/// <param name="name">The argument name.</param>
/// <returns>Whether or not the specified argument exist.</returns>
/// <example>
///            This sample shows how to call the <see cref="M:Cake.Common.ArgumentAliases.HasArgument(Cake.Core.ICakeContext,System.String)" /> method.
///            <code>
///            var argumentName = "myArgument";
///            //Cake.exe .\hasargument.cake -myArgument="is specified"
///            if (HasArgument(argumentName))
///            {
///                Information("{0} is specified", argumentName);
///            }
///            //Cake.exe .\hasargument.cake
///            else
///            {
///                Warning("{0} not specified", argumentName);
///            }
///            </code>
///            </example>
public System.Boolean HasArgument(System.String name)
{
    return Cake.Common.ArgumentAliases.HasArgument(Context, name);
}
```