### PR TITLE
GH79: Don't use only FileName for script file

### DIFF
--- a/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
@@ -78,7 +78,7 @@ namespace Cake.Scripting.CodeGen
 
             // Analyze the script file.
             _log.Verbose("Analyzing build script...");
-            var result = _analyzer.Analyze(scriptPath.GetFilename());
+            var result = _analyzer.Analyze(scriptPath);
 
             // Install addins.
             var addinRoot = GetAddinPath(_environment.WorkingDirectory);


### PR DESCRIPTION
- This fixes an issue where .cake files in subdirectory doesn't include source
- Fixes #79