### PR TITLE
GH80: Performance improvements

### DIFF
--- a/src/Cake.Bakery/CacheModule.cs
+++ b/src/Cake.Bakery/CacheModule.cs
@@ -7,6 +7,7 @@ using Cake.Bakery.Scripting;
 using Cake.Core;
 using Cake.Core.Composition;
 using Cake.Core.Scripting;
+using Cake.Scripting.CodeGen;
 using IScriptAliasFinder = Cake.Scripting.CodeGen.IScriptAliasFinder;
 
 namespace Cake.Bakery
@@ -16,12 +17,17 @@ namespace Cake.Bakery
         private readonly IScriptAliasFinder _aliasFinder;
         private readonly IScriptProcessor _processor;
         private readonly ICakeEnvironment _environment;
+        private readonly ICakeAliasGenerator _aliasGenerator;
 
-        public CacheModule(IScriptAliasFinder aliasFinder, IScriptProcessor processor, ICakeEnvironment environment)
+        public CacheModule(IScriptAliasFinder aliasFinder,
+            IScriptProcessor processor,
+            ICakeEnvironment environment,
+            ICakeAliasGenerator aliasGenerator)
         {
             _aliasFinder = aliasFinder ?? throw new ArgumentNullException(nameof(aliasFinder));
             _processor = processor ?? throw new ArgumentNullException(nameof(processor));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _aliasGenerator = aliasGenerator ?? throw new ArgumentNullException(nameof(aliasGenerator));
         }
 
         public void Register(ICakeContainerRegistrar registrar)
@@ -38,6 +44,9 @@ namespace Cake.Bakery
             var processor = new CachingScriptProcessor(_processor);
             registrar.RegisterInstance(processor)
                 .As<IScriptProcessor>();
+            var aliasGenerator = new CachingCakeAliasGenerator(_aliasGenerator);
+            registrar.RegisterInstance(aliasGenerator)
+                .As<ICakeAliasGenerator>();
         }
     }
 }

--- a/src/Cake.Bakery/Cake.Bakery.csproj
+++ b/src/Cake.Bakery/Cake.Bakery.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
     <WarningsAsErrors>true</WarningsAsErrors>
@@ -7,23 +6,18 @@
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
   </PropertyGroup>
-  
   <PropertyGroup>
     <Description>The Cake script analyzer and code generator.</Description>
   </PropertyGroup>
-  
   <Import Project="..\Shared.props" />
-  
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.23.0" />
     <PackageReference Include="Cake.NuGet" Version="0.23.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\Cake.Scripting.Abstractions\Cake.Scripting.Abstractions.csproj" />
     <ProjectReference Include="..\Cake.Scripting.Transport\Cake.Scripting.Transport.csproj" />
     <ProjectReference Include="..\Cake.Scripting\Cake.Scripting.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/Cake.Bakery/Program.cs
+++ b/src/Cake.Bakery/Program.cs
@@ -83,10 +83,11 @@ namespace Cake.Bakery
                 var environment = container.Resolve<ICakeEnvironment>();
                 var aliasFinder = container.Resolve<IScriptAliasFinder>();
                 var processor = container.Resolve<Core.Scripting.IScriptProcessor>();
+                var aliasGenerator = container.Resolve<ICakeAliasGenerator>();
 
                 // Rebuild the container for Cached Alias Finder.
                 registrar = new ContainerRegistrar();
-                registrar.RegisterModule(new CacheModule(aliasFinder, processor, environment));
+                registrar.RegisterModule(new CacheModule(aliasFinder, processor, environment, aliasGenerator));
                 registrar.Builder.Update(container);
 
                 // Get Script generator.

--- a/src/Cake.Bakery/Scripting/CachingCakeAliasGenerator.cs
+++ b/src/Cake.Bakery/Scripting/CachingCakeAliasGenerator.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Cake.Scripting.CodeGen;
+
+namespace Cake.Bakery.Scripting
+{
+    internal sealed class CachingCakeAliasGenerator : ICakeAliasGenerator
+    {
+        private readonly IDictionary<CakeScriptAlias, string> _cache;
+        private readonly ICakeAliasGenerator _aliasGenerator;
+
+        public CachingCakeAliasGenerator(ICakeAliasGenerator aliasGenerator)
+        {
+            _aliasGenerator = aliasGenerator ?? throw new ArgumentNullException(nameof(aliasGenerator));
+            _cache = new Dictionary<CakeScriptAlias, string>(new CakeScriptAliasComparer());
+        }
+
+        public void Generate(TextWriter writer, CakeScriptAlias alias)
+        {
+            if (!_cache.TryGetValue(alias, out string result))
+            {
+                using (var w = new StringWriter())
+                {
+                    _aliasGenerator.Generate(w, alias);
+                    result = w.ToString();
+                    _cache.Add(alias, result);
+                }
+            }
+
+            writer.Write(result);
+        }
+    }
+}

--- a/src/Cake.Bakery/Scripting/CakeScriptAliasComparer.cs
+++ b/src/Cake.Bakery/Scripting/CakeScriptAliasComparer.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Scripting.CodeGen;
+
+namespace Cake.Bakery.Scripting
+{
+    public class CakeScriptAliasComparer : IEqualityComparer<CakeScriptAlias>
+    {
+        public bool Equals(CakeScriptAlias x, CakeScriptAlias y)
+        {
+            if (x == null && y == null)
+            {
+                return true;
+            }
+            if (x == null || y == null)
+            {
+                return false;
+            }
+            if (x.Method == null && y.Method == null)
+            {
+                return true;
+            }
+            if (x.Method == null || y.Method == null)
+            {
+                return false;
+            }
+
+            return string.Equals(x.Method.CRef, y.Method.CRef, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(CakeScriptAlias obj)
+        {
+            if (obj?.Method?.CRef == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+            return obj.Method.CRef.ToUpperInvariant().GetHashCode();
+        }
+    }
+}

--- a/src/Cake.Scripting.Tests/Fixtures/CakeAliasGeneratorFixture.cs
+++ b/src/Cake.Scripting.Tests/Fixtures/CakeAliasGeneratorFixture.cs
@@ -15,7 +15,7 @@ using Cake.Scripting.Tests;
 namespace Cake.Scripting.Tests.Fixtures
 {
     public abstract class CakeAliasGeneratorFixture<T>
-        where T : CakeAliasGenerator
+        where T : ICakeAliasGenerator
     {
         private readonly Assembly _assembly;
         private readonly T _generator;

--- a/src/Cake.Scripting.Transport.Tests/Unit/Serialization/CakeScriptSerializerTests.cs
+++ b/src/Cake.Scripting.Transport.Tests/Unit/Serialization/CakeScriptSerializerTests.cs
@@ -26,7 +26,7 @@ namespace Cake.Scripting.Transport.Tests.Unit.Serialization
             public void ShouldThrowIfWriterIsNull()
             {
                 // Given, When
-                var exception = Record.Exception(() => CakeScriptSerializer.Serialize(null, CakeScript.Empty)) as ArgumentNullException;
+                var exception = Record.Exception(() => CakeScriptSerializer.Serialize(null, CakeScript.Empty, Constants.Protocol.Latest)) as ArgumentNullException;
 
                 // Then
                 Assert.NotNull(exception);
@@ -37,7 +37,7 @@ namespace Cake.Scripting.Transport.Tests.Unit.Serialization
             public void ShouldThrowIfCakeScriptIsNull()
             {
                 // Given, When
-                var exception = Record.Exception(() => CakeScriptSerializer.Serialize(_fixture.Writer, null)) as ArgumentNullException;
+                var exception = Record.Exception(() => CakeScriptSerializer.Serialize(_fixture.Writer, null, Constants.Protocol.Latest)) as ArgumentNullException;
 
                 // Then
                 Assert.NotNull(exception);
@@ -86,7 +86,7 @@ namespace Cake.Scripting.Transport.Tests.Unit.Serialization
                 var expected = _fixture.CreateCakeScriptFromResource(resource, 0, 0);
 
                 // When
-                CakeScriptSerializer.Serialize(_fixture.Writer, expected);
+                CakeScriptSerializer.Serialize(_fixture.Writer, expected, Constants.Protocol.Latest);
                 _fixture.ResetStreamPosition();
                 var actual = CakeScriptSerializer.Deserialize(_fixture.Reader);
 

--- a/src/Cake.Scripting.Transport/Serialization/CakeScriptSerializer.cs
+++ b/src/Cake.Scripting.Transport/Serialization/CakeScriptSerializer.cs
@@ -34,8 +34,6 @@ namespace Cake.Scripting.Transport.Serialization
             var bytes = Zip(script.Source);
             writer.Write(bytes.Length);
             writer.Write(bytes);
-            // TODO: Support non-zipped as well
-            // writer.WriteString(script.Source);
 
             // References
             writer.Write(script.References.Count);
@@ -76,8 +74,6 @@ namespace Cake.Scripting.Transport.Serialization
             var bytesLength = reader.ReadInt32();
             var bytes = reader.ReadBytes(bytesLength);
             cakeScript.Source = Unzip(bytes);
-            // TODO: Support non-zipped as well
-            // cakeScript.Source = reader.ReadString();
 
             // References
             var referencesLength = reader.ReadInt32();

--- a/src/Cake.Scripting.Transport/Serialization/Constants.cs
+++ b/src/Cake.Scripting.Transport/Serialization/Constants.cs
@@ -9,7 +9,7 @@ namespace Cake.Scripting.Transport.Serialization
         public static class CakeScript
         {
             public static readonly byte TypeId = 0x00;
-            public static readonly byte Version = 0x00;
+            public static readonly byte Version = 0x01;
             public static readonly short TypeAndVersion = (short)(TypeId << 8 | Version);
         }
 

--- a/src/Cake.Scripting.Transport/Serialization/Constants.cs
+++ b/src/Cake.Scripting.Transport/Serialization/Constants.cs
@@ -6,18 +6,28 @@ namespace Cake.Scripting.Transport.Serialization
 {
     internal static class Constants
     {
+        public static class Protocol
+        {
+            public static readonly byte V1 = 0x00;
+            public static readonly byte V2 = 0x01;
+
+            public static byte Latest => V2;
+        }
+
         public static class CakeScript
         {
             public static readonly byte TypeId = 0x00;
-            public static readonly byte Version = 0x01;
-            public static readonly short TypeAndVersion = (short)(TypeId << 8 | Version);
+            public static readonly short TypeAndVersion = WithVersion(Protocol.Latest);
+
+            public static short WithVersion(byte version) => (short)(TypeId << 8 | version);
         }
 
         public static class FileChange
         {
             public static readonly byte TypeId = 0x01;
-            public static readonly byte Version = 0x00;
-            public static readonly short TypeAndVersion = (short)(TypeId << 8 | Version);
+            public static readonly short TypeAndVersion = WithVersion(Protocol.Latest);
+
+            public static short WithVersion(byte version) => (short)(TypeId << 8 | version);
         }
     }
 }

--- a/src/Cake.Scripting.Transport/Tcp/Client/ScriptGenerationClient.cs
+++ b/src/Cake.Scripting.Transport/Tcp/Client/ScriptGenerationClient.cs
@@ -56,7 +56,7 @@ namespace Cake.Scripting.Transport.Tcp.Client
             {
                 // Send
                 _logger.LogDebug("Sending request to server");
-                FileChangeSerializer.Serialize(_writer, fileChange);
+                FileChangeSerializer.Serialize(_writer, fileChange, Constants.Protocol.Latest);
                 _writer.Flush();
 
                 while (!_stream.DataAvailable)

--- a/src/Cake.Scripting.Transport/Tcp/Server/ScriptGenerationServer.cs
+++ b/src/Cake.Scripting.Transport/Tcp/Server/ScriptGenerationServer.cs
@@ -70,7 +70,7 @@ namespace Cake.Scripting.Transport.Tcp.Server
 
                         // Request
                         _logger.LogDebug("Received reqeust from client");
-                        var fileChange = FileChangeSerializer.Deserialize(reader);
+                        var fileChange = FileChangeSerializer.Deserialize(reader, out var version);
                         var cakeScript = CakeScript.Empty;
 
                         try
@@ -84,7 +84,7 @@ namespace Cake.Scripting.Transport.Tcp.Server
 
                         // Response
                         _logger.LogDebug("Sending response to client");
-                        CakeScriptSerializer.Serialize(writer, cakeScript);
+                        CakeScriptSerializer.Serialize(writer, cakeScript, version);
                         writer.Flush();
                     }
                 }

--- a/src/Cake.Scripting/CodeGen/Generators/CakeAliasGenerationHelper.cs
+++ b/src/Cake.Scripting/CodeGen/Generators/CakeAliasGenerationHelper.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Cake.Scripting.CodeGen.Generators
+{
+    internal static class CakeAliasGenerationHelper
+    {
+        public static void WriteDocs(TextWriter writer, XElement element)
+        {
+            if (element != null)
+            {
+                var builder = new StringBuilder();
+                foreach (var xmlDoc in element.Elements())
+                {
+                    builder.AppendLine($"/// {xmlDoc.ToString().Replace("\n", "\n///")}");
+                }
+                writer.Write(builder.ToString());
+            }
+        }
+
+        public static string GetObsoleteMessage(CakeScriptAlias alias)
+        {
+            var message = string.Concat(" ", alias.Obsolete.Message ?? string.Empty).TrimEnd();
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                message = string.Empty;
+            }
+            message = $"The alias {alias.Method.Name} has been made obsolete.{message}";
+            return message;
+        }
+    }
+}

--- a/src/Cake.Scripting/CodeGen/Generators/CakeMethodAliasGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/Generators/CakeMethodAliasGenerator.cs
@@ -6,10 +6,11 @@ using System;
 using System.IO;
 using System.Linq;
 using Cake.Scripting.Reflection.Emitters;
+using static Cake.Scripting.CodeGen.Generators.CakeAliasGenerationHelper;
 
 namespace Cake.Scripting.CodeGen.Generators
 {
-    public sealed class CakeMethodAliasGenerator : CakeAliasGenerator
+    public sealed class CakeMethodAliasGenerator : ICakeAliasGenerator
     {
         private readonly TypeEmitter _typeEmitter;
         private readonly ParameterEmitter _parameterEmitter;
@@ -20,8 +21,13 @@ namespace Cake.Scripting.CodeGen.Generators
             _parameterEmitter = parameterEmitter ?? throw new ArgumentNullException(nameof(parameterEmitter));
         }
 
-        public override void Generate(TextWriter writer, CakeScriptAlias alias)
+        public void Generate(TextWriter writer, CakeScriptAlias alias)
         {
+            if (alias == null)
+            {
+                throw new ArgumentNullException(nameof(alias));
+            }
+
             Generate(new IndentedTextWriter(writer), alias);
         }
 

--- a/src/Cake.Scripting/CodeGen/Generators/CakePropertyAliasGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/Generators/CakePropertyAliasGenerator.cs
@@ -5,10 +5,11 @@
 using System;
 using System.IO;
 using Cake.Scripting.Reflection.Emitters;
+using static Cake.Scripting.CodeGen.Generators.CakeAliasGenerationHelper;
 
 namespace Cake.Scripting.CodeGen.Generators
 {
-    public sealed class CakePropertyAliasGenerator : CakeAliasGenerator
+    public sealed class CakePropertyAliasGenerator : ICakeAliasGenerator
     {
         private readonly TypeEmitter _typeEmitter;
 
@@ -17,7 +18,7 @@ namespace Cake.Scripting.CodeGen.Generators
             _typeEmitter = typeEmitter;
         }
 
-        public override void Generate(TextWriter writer, CakeScriptAlias alias)
+        public void Generate(TextWriter writer, CakeScriptAlias alias)
         {
             if (alias == null)
             {

--- a/src/Cake.Scripting/CodeGen/ICakeAliasGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/ICakeAliasGenerator.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+
+namespace Cake.Scripting.CodeGen
+{
+    public interface ICakeAliasGenerator
+    {
+        void Generate(TextWriter writer, CakeScriptAlias alias);
+    }
+}

--- a/src/Cake.Scripting/Properties/AssemblyInfo.cs
+++ b/src/Cake.Scripting/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Cake.Scripting.Tests")]

--- a/src/Cake.Scripting/ScriptingModule.cs
+++ b/src/Cake.Scripting/ScriptingModule.cs
@@ -8,6 +8,7 @@ using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Scripting.Abstractions;
 using Cake.Scripting.CodeGen;
+using Cake.Scripting.CodeGen.Generators;
 using Cake.Scripting.IO;
 
 namespace Cake.Scripting
@@ -39,6 +40,7 @@ namespace Cake.Scripting
             // Scripting
             registrar.RegisterType<CakeScriptAliasFinder>().As<IScriptAliasFinder>().Singleton();
             registrar.RegisterType<CakeScriptGenerator>().As<IScriptGenerationService>().Singleton();
+            registrar.RegisterType<CakeAliasGenerator>().As<ICakeAliasGenerator>().Singleton();
         }
     }
 }


### PR DESCRIPTION
Fixes #80 

I'm using a simple benchmark which uses the whole pipe as OmniSharp would.

Example code:
```csharp
public class BakeryGeneration
    {
        private readonly IScriptGenerationService _service;
        private readonly FileChange _fileChange;

        public BakeryGeneration()
        {
            _service = new ScriptGenerationClient("./Cake.Bakery.exe", Path.GetFullPath("./"), new LoggerFactory());
            _fileChange = new FileChange
            {
                Buffer = @"var target = Argument(""target"", ""Default"");

Task(""Default"")
  .Does(() =>
{
  Information(""Hello World!"");
});

RunTarget(target);",
                FileName = "build.cake",
                FromDisk = false
            };
        }

        [Benchmark]
        public CakeScript Generate() => _service.Generate(_fileChange);
    }

    public static class Program
    {
        public static void Main(string[] args)
        {
            var summary = BenchmarkRunner.Run<BakeryGeneration>();
        }
    }
```

Start.

|   Method |     Mean |    Error |   StdDev |
|--------- |---------:|---------:|---------:|
| Generate | 244.6 ms | 10.91 ms | 32.17 ms |