### PR TITLE
GH86: Add Cake.Common references to default list

### DIFF
--- a/src/Cake.Scripting/Cake.Scripting.csproj
+++ b/src/Cake.Scripting/Cake.Scripting.csproj
@@ -15,4 +15,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Cake.Scripting.Abstractions\Cake.Scripting.Abstractions.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Serialization" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Fixes #86
- In the future we should look at resolving these dynamically.