### PR TITLE
cake-scripting: Look for global cake installed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{cs,cake}]
+indent_style = space
+indent_size = 4

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.27.0" />
+    <package id="Cake" version="0.26.0" />
 </packages>


### PR DESCRIPTION
The logic to get the cake path now looks into the default path where global
dotnet-tools are being installed. After that it looks for cake inside the
default chocolately install path. Last but not least it looks locally
inside the tools path.

this fixes #108