### PR TITLE
GH-75: Adds caching LoadDirectiveProvider

### DIFF
--- a/src/Cake.Bakery/CacheModule.cs
+++ b/src/Cake.Bakery/CacheModule.cs
@@ -3,10 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Cake.Bakery.Scripting;
 using Cake.Core;
 using Cake.Core.Composition;
 using Cake.Core.Scripting;
+using Cake.Core.Scripting.Processors.Loading;
 using Cake.Scripting.CodeGen;
 using IScriptAliasFinder = Cake.Scripting.CodeGen.IScriptAliasFinder;
 
@@ -18,16 +20,19 @@ namespace Cake.Bakery
         private readonly IScriptProcessor _processor;
         private readonly ICakeEnvironment _environment;
         private readonly ICakeAliasGenerator _aliasGenerator;
+        private readonly IEnumerable<ILoadDirectiveProvider> _loadDirectiveProviders;
 
         public CacheModule(IScriptAliasFinder aliasFinder,
             IScriptProcessor processor,
             ICakeEnvironment environment,
-            ICakeAliasGenerator aliasGenerator)
+            ICakeAliasGenerator aliasGenerator,
+            IEnumerable<ILoadDirectiveProvider> loadDirectiveProviders)
         {
             _aliasFinder = aliasFinder ?? throw new ArgumentNullException(nameof(aliasFinder));
             _processor = processor ?? throw new ArgumentNullException(nameof(processor));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _aliasGenerator = aliasGenerator ?? throw new ArgumentNullException(nameof(aliasGenerator));
+            _loadDirectiveProviders = loadDirectiveProviders ?? throw new ArgumentNullException(nameof(loadDirectiveProviders));
         }
 
         public void Register(ICakeContainerRegistrar registrar)
@@ -47,6 +52,9 @@ namespace Cake.Bakery
             var aliasGenerator = new CachingCakeAliasGenerator(_aliasGenerator);
             registrar.RegisterInstance(aliasGenerator)
                 .As<ICakeAliasGenerator>();
+            var loadDirectiveProvider = new CachingLoadDirectiveProvider(_loadDirectiveProviders);
+            registrar.RegisterInstance(loadDirectiveProvider)
+                .As<ILoadDirectiveProvider>();
         }
     }
 }

--- a/src/Cake.Bakery/Program.cs
+++ b/src/Cake.Bakery/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -15,6 +16,7 @@ using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Modules;
+using Cake.Core.Scripting.Processors.Loading;
 using Cake.Core.Text;
 using Cake.NuGet;
 using Cake.Scripting;
@@ -84,10 +86,11 @@ namespace Cake.Bakery
                 var aliasFinder = container.Resolve<IScriptAliasFinder>();
                 var processor = container.Resolve<Core.Scripting.IScriptProcessor>();
                 var aliasGenerator = container.Resolve<ICakeAliasGenerator>();
+                var loadDirectiveProviders = container.Resolve<IEnumerable<ILoadDirectiveProvider>>();
 
                 // Rebuild the container for Cached Alias Finder.
                 registrar = new ContainerRegistrar();
-                registrar.RegisterModule(new CacheModule(aliasFinder, processor, environment, aliasGenerator));
+                registrar.RegisterModule(new CacheModule(aliasFinder, processor, environment, aliasGenerator, loadDirectiveProviders));
                 registrar.Builder.Update(container);
 
                 // Get Script generator.

--- a/src/Cake.Bakery/Scripting/CachingLoadDirectiveProvider.cs
+++ b/src/Cake.Bakery/Scripting/CachingLoadDirectiveProvider.cs
@@ -32,7 +32,7 @@ namespace Cake.Bakery.Scripting
                     return;
                 }
 
-                var interceptor = new InterceptingScriptAnalyzerContext();
+                var interceptor = new InterceptingScriptAnalyzerContext(context);
                 provider.Load(interceptor, reference);
                 result = interceptor.FilePaths;
 
@@ -45,22 +45,24 @@ namespace Cake.Bakery.Scripting
             }
         }
 
-        private class InterceptingScriptAnalyzerContext : IScriptAnalyzerContext
+        private sealed class InterceptingScriptAnalyzerContext : IScriptAnalyzerContext
         {
+            private readonly IScriptAnalyzerContext _context;
+
             public List<FilePath> FilePaths { get; } = new List<FilePath>();
 
-            public FilePath Root => throw new System.NotImplementedException();
+            public FilePath Root => _context.Root;
 
-            public IScriptInformation Current => throw new System.NotImplementedException();
+            public IScriptInformation Current => _context.Current;
+
+            public InterceptingScriptAnalyzerContext(IScriptAnalyzerContext context) => _context = context;
 
             public void AddScriptError(string error)
             {
-                throw new System.NotImplementedException();
             }
 
             public void AddScriptLine(string line)
             {
-                throw new System.NotImplementedException();
             }
 
             public void Analyze(FilePath scriptPath)

--- a/src/Cake.Bakery/Scripting/CachingLoadDirectiveProvider.cs
+++ b/src/Cake.Bakery/Scripting/CachingLoadDirectiveProvider.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core.IO;
+using Cake.Core.Scripting.Analysis;
+using Cake.Core.Scripting.Processors.Loading;
+
+namespace Cake.Bakery.Scripting
+{
+    internal sealed class CachingLoadDirectiveProvider : ILoadDirectiveProvider
+    {
+        private readonly IDictionary<LoadReference, IReadOnlyList<FilePath>> _cache;
+        private readonly IReadOnlyList<ILoadDirectiveProvider> _loadDirectiveProviders;
+
+        public CachingLoadDirectiveProvider(IEnumerable<ILoadDirectiveProvider> loadDirectiveProviders)
+        {
+            _loadDirectiveProviders = loadDirectiveProviders?.ToList() ?? throw new System.ArgumentNullException(nameof(loadDirectiveProviders));
+            _cache = new Dictionary<LoadReference, IReadOnlyList<FilePath>>(new LoadReferenceComparer());
+        }
+
+        public bool CanLoad(IScriptAnalyzerContext context, LoadReference reference)
+        {
+            return _loadDirectiveProviders.Any(x => x.CanLoad(context, reference));
+        }
+
+        public void Load(IScriptAnalyzerContext context, LoadReference reference)
+        {
+            if (!_cache.TryGetValue(reference, out IReadOnlyList<FilePath> result))
+            {
+                var provider = _loadDirectiveProviders.FirstOrDefault(x => x.CanLoad(context, reference));
+                if (provider == null)
+                {
+                    return;
+                }
+
+                var interceptor = new InterceptingScriptAnalyzerContext();
+                provider.Load(interceptor, reference);
+                result = interceptor.FilePaths;
+
+                _cache.Add(reference, result);
+            }
+
+            foreach (var file in result ?? Enumerable.Empty<FilePath>())
+            {
+                context.Analyze(file);
+            }
+        }
+
+        private class InterceptingScriptAnalyzerContext : IScriptAnalyzerContext
+        {
+            public List<FilePath> FilePaths { get; } = new List<FilePath>();
+
+            public FilePath Root => throw new System.NotImplementedException();
+
+            public IScriptInformation Current => throw new System.NotImplementedException();
+
+            public void AddScriptError(string error)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void AddScriptLine(string line)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Analyze(FilePath scriptPath)
+            {
+                FilePaths.Add(scriptPath);
+            }
+        }
+    }
+}

--- a/src/Cake.Bakery/Scripting/LoadReferenceComparer.cs
+++ b/src/Cake.Bakery/Scripting/LoadReferenceComparer.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using Cake.Core.Scripting.Processors.Loading;
+
+namespace Cake.Bakery.Scripting
+{
+    internal sealed class LoadReferenceComparer : IEqualityComparer<LoadReference>
+    {
+        public bool Equals(LoadReference x, LoadReference y)
+        {
+            if (x == null && y == null)
+            {
+                return true;
+            }
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            return string.Equals(x.OriginalString, y.OriginalString, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(LoadReference obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+            return obj.OriginalString.ToUpperInvariant().GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
- Fixes #75

@gep13 there should be some performance improvements now when using e.g. Cake.Recipe. Still not optimal due to the actual size of the file which is passed to Roslyn.