### PR TITLE
(GH-127) Fixed wrong path in cake-tool detection

### DIFF
--- a/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
@@ -261,7 +261,7 @@ namespace Cake.Scripting.CodeGen
                     userDotNetToolsPaths
                         .Union(directoriesInPath)
                         .Select(dir => dir.CombineWithFilePath(exe)))
-                .FirstOrDefault(x => _fileSystem.Exist(x));
+                .FirstOrDefault(x => _fileSystem.Exist(x))?.GetDirectory();
             if (dotnetCakePath != null)
             {
                 pattern = string.Concat(dotnetCakePath.FullPath, "/.store/**/Cake.dll");


### PR DESCRIPTION
The last change introduced a detection based on
the dotnet tool default installation location.
During that change the "dotnetCakePath" was erroneously
modified from pointing to the folder in which dotnet-cake resides
to the dotnet-cake file itself. This commit reverts that.

fixes #127 