### PR TITLE
(GH-129) When using .NET Global tool, resolve Cake.dll to netcoreapp3.1

### DIFF
--- a/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
@@ -264,8 +264,8 @@ namespace Cake.Scripting.CodeGen
                 .FirstOrDefault(x => _fileSystem.Exist(x))?.GetDirectory();
             if (dotnetCakePath != null)
             {
-                pattern = string.Concat(dotnetCakePath.FullPath, "/.store/**/Cake.dll");
-                var cakeDllPath = _globber.GetFiles(pattern).FirstOrDefault();
+                pattern = string.Concat(dotnetCakePath.FullPath, "/.store/**/^{netcoreapp3.1,netcoreapp2.1}/**/Cake.dll");
+                var cakeDllPath = _globber.GetFiles(pattern).LastOrDefault();
 
                 if (cakeDllPath != null)
                 {


### PR DESCRIPTION
Bakery currently needs `Cake.Core` and `Cake.Common` targeting `netstandard2.0` only as per @bjorkstromm's comment https://github.com/cake-build/bakery/issues/129#issuecomment-792359060