### PR TITLE
GH163: Only find aliases in CLR assemblies

### DIFF
--- a/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
@@ -126,11 +126,11 @@ namespace Cake.Scripting.CodeGen
             // Find aliases
             _log.Verbose("Finding aliases...");
             var aliases = new List<CakeScriptAlias>();
-            foreach (var reference in references)
+            foreach (var reference in references.Select(_fileSystem.GetFile))
             {
-                if (_fileSystem.Exist(reference))
+                if (reference.Exists && reference.IsClrAssembly())
                 {
-                    aliases.AddRange(_aliasFinder.FindAliases(reference));
+                    aliases.AddRange(_aliasFinder.FindAliases(reference.Path));
                 }
             }
 

--- a/src/Cake.Scripting/Reflection/GenericParameterSignature.cs
+++ b/src/Cake.Scripting/Reflection/GenericParameterSignature.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Cake.Scripting.Reflection.Emitters;
 using Mono.Cecil;
 


### PR DESCRIPTION
* fixes #163

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/1647294/145640523-e06ffa94-0d67-4229-a60e-543e8614f726.png">
