### PR TITLE
(#168) do not load dlls under runtimes

### DIFF
--- a/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
+++ b/src/Cake.Scripting/CodeGen/CakeScriptGenerator.cs
@@ -103,6 +103,16 @@ namespace Cake.Scripting.CodeGen
                     var addinReferences = _processor.InstallAddins(new[] { addin }, _addinRoot);
                     foreach (var addinReference in addinReferences)
                     {
+                        // remove the 'runtimes' dlls
+                        var isInRuntimes = addinReference.Segments
+                            .Skip(_addinRoot.Segments.Length)
+                            .Any(s => s.Equals("runtimes", StringComparison.OrdinalIgnoreCase));
+                        if (isInRuntimes)
+                        {
+                            _log.Verbose($"Ignoring {addinReference.FullPath} as it resides under 'runtimes'.");
+                            continue;
+                        }
+
                         result.References.Add(addinReference.FullPath);
                     }
                 }


### PR DESCRIPTION
As @bjorkstromm stated in https://github.com/cake-contrib/Cake_Git/issues/160#issuecomment-995176148: 

> Cake.Bakery should ignore everything in runtimes/ folder as these are not needed during compilation. 

This PR removes all `dll`s from being loaded that are pulled in as addins and reside under the `runtimes` folder. 

fixes #168 